### PR TITLE
Fix: Relocate text animation to preserve circular photo shape

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,12 +105,12 @@
       <h2 class="text-3xl md:text-4xl font-bold mb-6 gradient-text">About Me</h2>
       <img src="./assets/images/Paulo-Brocco.jpg" alt="Paulo Brocco"
         class="w-32 h-32 md:w-40 md-h-40 rounded-full mx-auto mb-6 border-4 border-purple-600 shadow-lg">
-      <p class="text-sm text-green-400 font-mono mb-4" aria-hidden="true"><span
-          class="typing-subtitle">Dev_Oxx.orcus</span></p>
       <p class="text-gray-300 text-lg mb-4 leading-relaxed">I'm a 32-year-old developer from São Paulo, Brazil,
         currently based in Cork, Ireland. I'm passionate about solving complex problems using cutting-edge technology.
         Over the past ~5 years I've focused on building systems and automation that reach and help thousands of users.
       </p>
+      <p class="text-sm text-green-400 font-mono mb-4" aria-hidden="true"><span
+          class="typing-subtitle">Dev_Oxx.orcus</span></p>
       <p class="text-gray-400 text-sm mb-6">Languages: Portuguese (Native) • English (B2) • Availability: Open to
         opportunities and collaborations.</p>
       <div class="flex flex-wrap justify-center gap-3 text-sm">


### PR DESCRIPTION
This pull request makes a minor adjustment to the `index.html` file by restoring the "Dev_Oxx.orcus" subtitle in the About Me section. 