### PR TITLE
🧪 add test for empty message in Chat API

### DIFF
--- a/tests/api_chat.test.js
+++ b/tests/api_chat.test.js
@@ -133,6 +133,24 @@ test('Chat API returns 400 for non-string message input', async (t) => {
     }
 });
 
+test('Chat API returns 400 for empty or whitespace-only message', async (t) => {
+    process.env.GEMINI_API_KEY = 'test-key';
+    const handler = getHandler();
+
+    const invalidInputs = [
+        { message: "" },
+        { message: "   " }
+    ];
+
+    for (const body of invalidInputs) {
+        const { req, res, getStatus, getJson } = mockReqRes({ body });
+        await handler(req, res);
+        assert.strictEqual(getStatus(), 400, `Expected 400 for input: ${JSON.stringify(body)}`);
+        assert.strictEqual(getJson().success, false);
+        assert.strictEqual(getJson().message, "User message is required.");
+    }
+});
+
 test('Chat API returns 429 for too many requests', async (t) => {
     process.env.GEMINI_API_KEY = 'test-key';
     const handler = getHandler();


### PR DESCRIPTION
🎯 **What:** The Chat API had an untested edge case for empty or whitespace-only message strings.
📊 **Coverage:** Added a test case in `tests/api_chat.test.js` that covers:
- Empty string (`""`) input.
- Whitespace-only string (`"   "`) input.
✨ **Result:** Increased the reliability of the Chat API input validation by ensuring it correctly identifies and rejects empty or meaningless messages with a 400 Bad Request status.

---
*PR created automatically by Jules for task [9703217009719779547](https://jules.google.com/task/9703217009719779547) started by @OxxOrcus*